### PR TITLE
Add to FrameXML

### DIFF
--- a/EmmyLua/FrameXML/MapUtil.lua
+++ b/EmmyLua/FrameXML/MapUtil.lua
@@ -8,7 +8,7 @@ function MapUtil.IsMapTypeZone(mapID) end
 
 ---@param mapID number
 ---@param mapType UIMapType
----@param topMost boolean
+---@param topMost? boolean
 ---@return UiMapDetails
 ---[FrameXML](https://www.townlong-yak.com/framexml/live/MapUtil.lua)
 function MapUtil.GetMapParentInfo(mapID, mapType, topMost) end

--- a/EmmyLua/FrameXML/MapUtil.lua
+++ b/EmmyLua/FrameXML/MapUtil.lua
@@ -1,0 +1,79 @@
+---[FrameXML](https://www.townlong-yak.com/framexml/live/MapUtil.lua)
+MapUtil = {}
+
+---@param mapID number
+---@return boolean
+---[FrameXML](https://www.townlong-yak.com/framexml/live/MapUtil.lua)
+function MapUtil.IsMapTypeZone(mapID) end
+
+---@param mapID number
+---@param mapType UIMapType
+---@param topMost boolean
+---@return UiMapDetails
+---[FrameXML](https://www.townlong-yak.com/framexml/live/MapUtil.lua)
+function MapUtil.GetMapParentInfo(mapID, mapType, topMost) end
+
+---@param mapType UIMapType
+---@return boolean
+---[FrameXML](https://www.townlong-yak.com/framexml/live/MapUtil.lua)
+function MapUtil.ShouldMapTypeShowQuests(mapType) end
+
+---@param mapID number
+---@param info TaskPOIData
+---@return boolean
+---[FrameXML](https://www.townlong-yak.com/framexml/live/MapUtil.lua)
+function MapUtil.ShouldShowTask(mapID, info) end
+
+---@param mapID number
+---@return boolean
+---[FrameXML](https://www.townlong-yak.com/framexml/live/MapUtil.lua)
+function MapUtil.MapHasUnlockedBounties(mapID) end
+
+---@param mapID number
+---@return boolean
+---[FrameXML](https://www.townlong-yak.com/framexml/live/MapUtil.lua)
+function MapUtil.MapHasEmissaries(mapID) end
+
+---@param mapID number
+---@param normalizedCursorX number
+---@param normalizedCursorY number
+---@return string|nil
+---[FrameXML](https://www.townlong-yak.com/framexml/live/MapUtil.lua)
+function MapUtil.FindBestAreaNameAtMouse(mapID, normalizedCursorX, normalizedCursorY) end
+
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/MapUtil.lua)
+function MapUtil.GetDisplayableMapForPlayer() end
+
+---@param bountySetID number
+---@return number[]
+---[FrameXML](https://www.townlong-yak.com/framexml/live/MapUtil.lua)
+function MapUtil.GetBountySetMaps(bountySetID) end
+
+---@param mapID number
+---@param topMapID number
+---@return number|nil centerX
+---@return number|nil centerY
+---[FrameXML](https://www.townlong-yak.com/framexml/live/MapUtil.lua)
+function MapUtil.GetMapCenterOnMap(mapID, topMapID) end
+
+---@param mapID number
+---@param ancestorMapID number
+---@return boolean
+---[FrameXML](https://www.townlong-yak.com/framexml/live/MapUtil.lua)
+function MapUtil.IsChildMap(mapID, ancestorMapID) end
+
+---@param mapID number
+---@return boolean
+---[FrameXML](https://www.townlong-yak.com/framexml/live/MapUtil.lua)
+function MapUtil.IsOribosMap(mapID) end
+
+---@param mapID number
+---@return boolean
+---[FrameXML](https://www.townlong-yak.com/framexml/live/MapUtil.lua)
+function MapUtil.IsShadowlandsZoneMap(mapID) end
+
+---@param mapID number
+---@return boolean
+---[FrameXML](https://www.townlong-yak.com/framexml/live/MapUtil.lua)
+function MapUtil.MapShouldShowWorldQuestFilters(mapID) end

--- a/EmmyLua/SharedXML/Color.lua
+++ b/EmmyLua/SharedXML/Color.lua
@@ -19,29 +19,29 @@ function CreateColor(r, g, b, a) end
 ---[FrameXML](https://www.townlong-yak.com/framexml/go/ColorMixin:IsEqualTo)
 function ColorMixin:IsEqualTo(otherColor) end
 
----@return number
----@return number
----@return number
+---@return number r
+---@return number g
+---@return number b
 ---[FrameXML](https://www.townlong-yak.com/framexml/go/ColorMixin:GetRGB)
 function ColorMixin:GetRGB() end
 
----@return number
----@return number
----@return number
+---@return number r
+---@return number g
+---@return number b
 ---[FrameXML](https://www.townlong-yak.com/framexml/go/ColorMixin:GetRGBAsBytes)
 function ColorMixin:GetRGBAsBytes() end
 
----@return number
----@return number
----@return number
----@return number
+---@return number r
+---@return number g
+---@return number b
+---@return number a
 ---[FrameXML](https://www.townlong-yak.com/framexml/go/ColorMixin:GetRGBA)
 function ColorMixin:GetRGBA() end
 
----@return number
----@return number
----@return number
----@return number
+---@return number r
+---@return number g
+---@return number b
+---@return number a
 ---[FrameXML](https://www.townlong-yak.com/framexml/go/ColorMixin:GetRGBAAsBytes)
 function ColorMixin:GetRGBAAsBytes() end
 

--- a/EmmyLua/SharedXML/Color.lua
+++ b/EmmyLua/SharedXML/Color.lua
@@ -9,7 +9,7 @@ ColorMixin = {}
 ---@param r number
 ---@param g number
 ---@param b number
----@param a number
+---@param a? number
 ---@return ColorMixin
 ---[FrameXML](https://www.townlong-yak.com/framexml/go/CreateColor)
 function CreateColor(r, g, b, a) end
@@ -34,21 +34,21 @@ function ColorMixin:GetRGBAsBytes() end
 ---@return number r
 ---@return number g
 ---@return number b
----@return number a
+---@return number? a
 ---[FrameXML](https://www.townlong-yak.com/framexml/go/ColorMixin:GetRGBA)
 function ColorMixin:GetRGBA() end
 
 ---@return number r
 ---@return number g
 ---@return number b
----@return number a
+---@return number? a
 ---[FrameXML](https://www.townlong-yak.com/framexml/go/ColorMixin:GetRGBAAsBytes)
 function ColorMixin:GetRGBAAsBytes() end
 
 ---@param r number
 ---@param g number
 ---@param b number
----@param a number
+---@param a? number
 ---[FrameXML](https://www.townlong-yak.com/framexml/go/ColorMixin:SetRGBA)
 function ColorMixin:SetRGBA(r, g, b, a) end
 

--- a/EmmyLua/SharedXML/ColorUtil.lua
+++ b/EmmyLua/SharedXML/ColorUtil.lua
@@ -1,8 +1,9 @@
----@class ColorMixinRCC : ColorMixin
+---@class RaidClassColors_Subtable:ColorMixin
 ---@field colorStr string
-local ColorMixin = {}
+local RaidClassColors_Subtable = {}
 
----@type table<string, ColorMixinRCC>
+---@type table<string, RaidClassColors_Subtable>
+---[FrameXML](https://www.townlong-yak.com/framexml/live/ColorUtil.lua)
 RAID_CLASS_COLORS = {
 	WARRIOR = {},
 	PALADIN = {},
@@ -17,3 +18,46 @@ RAID_CLASS_COLORS = {
 	DRUID = {},
 	DEMONHUNTER = {},
 }
+
+---@param hexColor string
+---@return ColorMixin
+---[FrameXML](https://www.townlong-yak.com/framexml/go/CreateColorFromHexString)
+function CreateColorFromHexString(hexColor) end
+
+---@param r number
+---@param g number
+---@param b number
+---@param a number
+---@return ColorMixin
+---[FrameXML](https://www.townlong-yak.com/framexml/go/CreateColorFromBytes)
+function CreateColorFromBytes(r, g, b, a) end
+
+---@param left ColorMixin
+---@param right ColorMixin
+---@return boolean
+---[FrameXML](https://www.townlong-yak.com/framexml/go/AreColorsEqual)
+function AreColorsEqual(left, right) end
+
+---@param classFilename string
+---@return number r
+---@return number g
+---@return number b
+---@return string colorStr
+---[FrameXML](https://www.townlong-yak.com/framexml/go/GetClassColor)
+function GetClassColor(classFilename) end
+
+---@param classFilename string
+---@return RaidClassColors_Subtable
+---[FrameXML](https://www.townlong-yak.com/framexml/go/GetClassColorObj)
+function GetClassColorObj(classFilename) end
+
+---@param unit string
+---@param text string
+---@return string
+---[FrameXML](https://www.townlong-yak.com/framexml/go/GetClassColoredTextForUnit)
+function GetClassColoredTextForUnit(unit, text) end
+
+---@param factionGroupTag string
+---@return ColorMixin
+---[FrameXML](https://www.townlong-yak.com/framexml/go/GetFactionColor)
+function GetFactionColor(factionGroupTag) end

--- a/EmmyLua/SharedXML/EasingUtil.lua
+++ b/EmmyLua/SharedXML/EasingUtil.lua
@@ -1,0 +1,62 @@
+---[FrameXML](https://www.townlong-yak.com/framexml/live/EasingUtil.lua)
+EasingUtil = {}
+
+---@param percent number Value from 0.0 to 1.0
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/EasingUtil.lua)
+function EasingUtil.InQuadratic(percent) end
+
+---@param percent number Value from 0.0 to 1.0
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/EasingUtil.lua)
+function EasingUtil.OutQuadratic(percent) end
+
+---@param percent number Value from 0.0 to 1.0
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/EasingUtil.lua)
+function EasingUtil.InOutQuadratic(percent) end
+
+---@param percent number Value from 0.0 to 1.0
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/EasingUtil.lua)
+function EasingUtil.InCubic(percent) end
+
+---@param percent number Value from 0.0 to 1.0
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/EasingUtil.lua)
+function EasingUtil.OutCubic(percent) end
+
+---@param percent number Value from 0.0 to 1.0
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/EasingUtil.lua)
+function EasingUtil.InOutCubic(percent) end
+
+---@param percent number Value from 0.0 to 1.0
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/EasingUtil.lua)
+function EasingUtil.InQuartic(percent) end
+
+---@param percent number Value from 0.0 to 1.0
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/EasingUtil.lua)
+function EasingUtil.OutQuartic(percent) end
+
+---@param percent number Value from 0.0 to 1.0
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/EasingUtil.lua)
+function EasingUtil.InOutQuartic(percent) end
+
+---@param percent number Value from 0.0 to 1.0
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/EasingUtil.lua)
+function EasingUtil.InQuintic(percent) end
+
+---@param percent number Value from 0.0 to 1.0
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/EasingUtil.lua)
+function EasingUtil.OutQuintic(percent) end
+
+---@param percent number Value from 0.0 to 1.0
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/EasingUtil.lua)
+function EasingUtil.InOutQuintic(percent) end

--- a/EmmyLua/SharedXML/PixelUtil.lua
+++ b/EmmyLua/SharedXML/PixelUtil.lua
@@ -1,0 +1,51 @@
+---[FrameXML](https://www.townlong-yak.com/framexml/live/PixelUtil.lua)
+PixelUtil = {}
+
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/PixelUtil.lua)
+function PixelUtil.GetPixelToUIUnitFactor() end
+
+---@param uiUnitSize number
+---@param layoutScale number
+---@param minPixels? number
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/PixelUtil.lua)
+function PixelUtil.GetNearestPixelSize(uiUnitSize, layoutScale, minPixels) end
+
+---@param region Region|string
+---@param width number
+---@param minPixels? number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/PixelUtil.lua)
+function PixelUtil.SetWidth(region, width, minPixels) end
+
+---@param region Region|string
+---@param height number
+---@param minPixels? number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/PixelUtil.lua)
+function PixelUtil.SetHeight(region, height, minPixels) end
+
+---@param region Region|string
+---@param width number
+---@param height number
+---@param minWidthPixels? number
+---@param minHeightPixels? number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/PixelUtil.lua)
+function PixelUtil.SetSize(region, width, height, minWidthPixels, minHeightPixels) end
+
+---@param region Region|string
+---@param point AnchorPoint
+---@param relativeTo Region|string
+---@param relativePoint AnchorPoint
+---@param offsetX number
+---@param offsetY number
+---@param minOffsetXPixels? number
+---@param minOffsetYPixels? number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/PixelUtil.lua)
+function PixelUtil.SetPoint(region, point, relativeTo, relativePoint, offsetX, offsetY, minOffsetXPixels, minOffsetYPixels) end
+
+--There is currently no StatusBar as widget type. So the last function is commented out.
+
+--[[ ---@param statusBar StatusBar
+---@param value number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/PixelUtil.lua)
+function PixelUtil.SetStatusBarValue(statusBar, value) end ]]

--- a/EmmyLua/SharedXML/PixelUtil.lua
+++ b/EmmyLua/SharedXML/PixelUtil.lua
@@ -12,13 +12,13 @@ function PixelUtil.GetPixelToUIUnitFactor() end
 ---[FrameXML](https://www.townlong-yak.com/framexml/live/PixelUtil.lua)
 function PixelUtil.GetNearestPixelSize(uiUnitSize, layoutScale, minPixels) end
 
----@param region Region|string
+---@param region Region
 ---@param width number
 ---@param minPixels? number
 ---[FrameXML](https://www.townlong-yak.com/framexml/live/PixelUtil.lua)
 function PixelUtil.SetWidth(region, width, minPixels) end
 
----@param region Region|string
+---@param region Region
 ---@param height number
 ---@param minPixels? number
 ---[FrameXML](https://www.townlong-yak.com/framexml/live/PixelUtil.lua)
@@ -32,7 +32,7 @@ function PixelUtil.SetHeight(region, height, minPixels) end
 ---[FrameXML](https://www.townlong-yak.com/framexml/live/PixelUtil.lua)
 function PixelUtil.SetSize(region, width, height, minWidthPixels, minHeightPixels) end
 
----@param region Region|string
+---@param region Region
 ---@param point AnchorPoint
 ---@param relativeTo Region|string
 ---@param relativePoint AnchorPoint

--- a/EmmyLua/SharedXML/PixelUtil.lua
+++ b/EmmyLua/SharedXML/PixelUtil.lua
@@ -24,7 +24,7 @@ function PixelUtil.SetWidth(region, width, minPixels) end
 ---[FrameXML](https://www.townlong-yak.com/framexml/live/PixelUtil.lua)
 function PixelUtil.SetHeight(region, height, minPixels) end
 
----@param region Region|string
+---@param region Region
 ---@param width number
 ---@param height number
 ---@param minWidthPixels? number

--- a/EmmyLua/SharedXML/TimeUtil.lua
+++ b/EmmyLua/SharedXML/TimeUtil.lua
@@ -1,0 +1,199 @@
+---False in some locale specific files.
+---
+---[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
+---@type boolean
+TIME_UTIL_WHITE_SPACE_STRIPPABLE = true
+
+---@type number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
+SECONDS_PER_MIN = 0
+
+---@type number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
+SECONDS_PER_HOUR = 0
+
+---@type number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
+SECONDS_PER_DAY = 0
+
+---@type number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
+SECONDS_PER_MONTH = 0
+
+---@type number
+---[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
+SECONDS_PER_YEAR = 0
+
+---@param seconds number
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsToMinutes)
+function SecondsToMinutes(seconds) end
+
+---@param minutes number
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/go/MinutesToSeconds)
+function MinutesToSeconds(minutes) end
+
+---@param testTime number Time in seconds since the Unix epoch
+---@param amountOfTime number Amount of time in seconds
+---@return boolean
+---[FrameXML](https://www.townlong-yak.com/framexml/go/HasTimePassed)
+function HasTimePassed(testTime, amountOfTime) end
+
+---Seconds formatter to standardize representations of seconds
+---
+---[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
+SecondsFormatter = {};
+
+---[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
+SecondsFormatter.Abbreviation = {
+	None = 1,
+	Truncate = 2,
+	OneLetter = 3,
+}
+
+---[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
+SecondsFormatter.Interval = {
+	Seconds = 1,
+	Minutes = 2,
+	Hours = 3,
+	Days = 4,
+}
+
+---@class IntervalDescription_Subtable:table
+---@field seconds number
+---@field formatString string[]
+local IntervalDescription_Subtable = {}
+
+---@type table<number, IntervalDescription_Subtable>
+---[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
+SecondsFormatter.IntervalDescription = {
+    [1] = {},
+	[2] = {},
+	[3] = {},
+	[4] = {}
+}
+
+---@class SecondsFormatterMixin
+---@field approximationSeconds number|nil
+---@field defaultAbbreviation number|nil
+---@field roundUpLastUnit boolean|nil
+---@field stripIntervalWhitespace boolean|nil
+---@field convertToLower boolean|nil
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsFormatterMixin)
+SecondsFormatterMixin = {}
+
+---@param approximationSeconds number Threshold for representing the seconds as an approximation (ex. "≤ 2 hours").
+---@param defaultAbbreviation number The default abbreviation for the format. Can be overrridden in `SecondsFormatterMixin:Format()`. Use one of `SecondsFormatter.Abbreviation`
+---@param roundUpLastUnit boolean Determines if the last unit in the output format string is ceiled (floored by default).
+---@param convertToLower boolean Converts the format string to lowercase.
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsFormatterMixin:Init)
+function SecondsFormatterMixin:Init(approximationSeconds, defaultAbbreviation, roundUpLastUnit, convertToLower) end
+
+---@param strip boolean
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsFormatterMixin:SetStripIntervalWhitespace)
+function SecondsFormatterMixin:SetStripIntervalWhitespace(strip) end
+
+---@return boolean
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsFormatterMixin:GetStripIntervalWhitespace)
+function SecondsFormatterMixin:GetStripIntervalWhitespace() end
+
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsFormatterMixin:GetMaxInterval)
+function SecondsFormatterMixin:GetMaxInterval() end
+
+---@param interval number Use one of `SecondsFormatter.Interval`
+---@return IntervalDescription_Subtable
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsFormatterMixin:GetIntervalDescription)
+function SecondsFormatterMixin:GetIntervalDescription(interval) end
+
+---@param interval number Use one of `SecondsFormatter.Interval`
+---@return number|nil
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsFormatterMixin:GetIntervalSeconds)
+function SecondsFormatterMixin:GetIntervalSeconds(interval) end
+
+---@param seconds number
+---@return boolean
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsFormatterMixin:CanApproximate)
+function SecondsFormatterMixin:CanApproximate(seconds) end
+
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsFormatterMixin:GetDefaultAbbreviation)
+function SecondsFormatterMixin:GetDefaultAbbreviation() end
+
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsFormatterMixin:GetApproximationSeconds)
+function SecondsFormatterMixin:GetApproximationSeconds() end
+
+---@return boolean
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsFormatterMixin:CanRoundUpLastUnit)
+function SecondsFormatterMixin:CanRoundUpLastUnit() end
+
+---@param seconds number
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsFormatterMixin:GetDesiredUnitCount)
+function SecondsFormatterMixin:GetDesiredUnitCount(seconds) end
+
+---@param seconds number
+---@return number
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsFormatterMixin:GetMinInterval)
+function SecondsFormatterMixin:GetMinInterval(seconds) end
+
+---@param interval number Use one of `SecondsFormatter.Interval`
+---@param abbreviation number Use one of `SecondsFormatter.Abbreviation`
+---@param convertToLower? boolean
+---@return string
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsFormatterMixin:GetFormatString)
+function SecondsFormatterMixin:GetFormatString(interval, abbreviation, convertToLower) end
+
+---@param abbreviation number Use one of `SecondsFormatter.Abbreviation`
+---@param toLower? boolean
+---@return string
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsFormatterMixin:FormatZero)
+function SecondsFormatterMixin:FormatZero(abbreviation, toLower) end
+
+---@param millseconds number
+---@param abbreviation? number Use one of `SecondsFormatter.Abbreviation`
+---@return string
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsFormatterMixin:FormatMillseconds)
+function SecondsFormatterMixin:FormatMillseconds(millseconds, abbreviation) end
+
+---@param seconds number
+---@param abbreviation? number Use one of `SecondsFormatter.Abbreviation`
+---@return string
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsFormatterMixin:Format)
+function SecondsFormatterMixin:Format(seconds, abbreviation) end
+
+---@param seconds number
+---@param displayZeroHours? boolean
+---@return string
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsToClock)
+function SecondsToClock(seconds, displayZeroHours) end
+
+---@param seconds number
+---@param noSeconds? boolean
+---@param notAbbreviated? boolean
+---@param maxCount? number
+---@param roundUp? boolean
+---@return string
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsToTime)
+function SecondsToTime(seconds, noSeconds, notAbbreviated, maxCount, roundUp) end
+
+---@param mins number
+---@param hideDays? boolean Only show days if hideDays is false
+---@return string
+---[FrameXML](https://www.townlong-yak.com/framexml/go/MinutesToTime)
+function MinutesToTime(mins, hideDays) end
+
+---@param seconds number
+---@return string format
+---@return number time
+---[FrameXML](https://www.townlong-yak.com/framexml/go/SecondsToTimeAbbrev)
+function SecondsToTimeAbbrev(seconds) end
+
+---@param day number
+---@param month number
+---@param year number
+---@return string
+---[FrameXML](https://www.townlong-yak.com/framexml/go/FormatShortDate)
+function FormatShortDate(day, month, year) end

--- a/EmmyLua/SharedXML/TimeUtil.lua
+++ b/EmmyLua/SharedXML/TimeUtil.lua
@@ -1,27 +1,20 @@
 ---False in some locale specific files.
----
----[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
 ---@type boolean
 TIME_UTIL_WHITE_SPACE_STRIPPABLE = true
 
 ---@type number
----[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
 SECONDS_PER_MIN = 0
 
 ---@type number
----[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
 SECONDS_PER_HOUR = 0
 
 ---@type number
----[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
 SECONDS_PER_DAY = 0
 
 ---@type number
----[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
 SECONDS_PER_MONTH = 0
 
 ---@type number
----[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
 SECONDS_PER_YEAR = 0
 
 ---@param seconds number
@@ -41,7 +34,6 @@ function MinutesToSeconds(minutes) end
 function HasTimePassed(testTime, amountOfTime) end
 
 ---Seconds formatter to standardize representations of seconds
----
 ---[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
 SecondsFormatter = {};
 

--- a/EmmyLua/SharedXML/TimeUtil.lua
+++ b/EmmyLua/SharedXML/TimeUtil.lua
@@ -68,7 +68,7 @@ local IntervalDescription_Subtable = {}
 ---@type table<number, IntervalDescription_Subtable>
 ---[FrameXML](https://www.townlong-yak.com/framexml/live/TimeUtil.lua)
 SecondsFormatter.IntervalDescription = {
-    [1] = {},
+	[1] = {},
 	[2] = {},
 	[3] = {},
 	[4] = {}

--- a/EmmyLua/SharedXML/Vector2D.lua
+++ b/EmmyLua/SharedXML/Vector2D.lua
@@ -21,8 +21,8 @@ function AreVector2DEqual(left, right) end
 ---[FrameXML](https://www.townlong-yak.com/framexml/go/Vector2DMixin:IsEqualTo)
 function Vector2DMixin:IsEqualTo(otherVector) end
 
----@return number
----@return number
+---@return number x
+---@return number y
 ---[FrameXML](https://www.townlong-yak.com/framexml/go/Vector2DMixin:GetXY)
 function Vector2DMixin:GetXY() end
 

--- a/EmmyLua/SharedXML/Vector3D.lua
+++ b/EmmyLua/SharedXML/Vector3D.lua
@@ -22,8 +22,8 @@ function Vector3D_NormalizeVector(vector) end
 function Vector3D_ScaleVector(scalar, vector) end
 
 ---@param vector Vector3DMixin
----@return number
----@return number
+---@return number yaw
+---@return number pitch
 ---[FrameXML](https://www.townlong-yak.com/framexml/go/Vector3D_CalculateYawPitchFromNormalVector)
 function Vector3D_CalculateYawPitchFromNormalVector(vector) end
 
@@ -58,9 +58,9 @@ function AreVector3DEqual(left, right) end
 ---[FrameXML](https://www.townlong-yak.com/framexml/go/Vector3DMixin:IsEqualTo)
 function Vector3DMixin:IsEqualTo(otherVector) end
 
----@return number
----@return number
----@return number
+---@return number x
+---@return number y
+---@return number z
 ---[FrameXML](https://www.townlong-yak.com/framexml/go/Vector3DMixin:GetXYZ)
 function Vector3DMixin:GetXYZ() end
 


### PR DESCRIPTION
Adds global objects, functions and methods from the following files:

- FrameXML/MapUtil.lua
- SharedXML/EasingUtil.lua
- SharedXML/PixelUtil.lua
- SharedXML/TimeUtil.lua

Adds more functions to SharedXML/ColorUtil.lua


Some notes:

1. There is a problem using links to site `www.townlong-yak.com` for objects. Links like `https://www.townlong-yak.com/framexml/go/{object}` seem to be supported only for functions and mixins. It doesn't work for everything else, including functions like `MapUtil.IsMapTypeZone()`
 Therefore, in such cases, I've added a link to file in which a given object is defined. Example: `https://www.townlong-yak.com/framexml/live/MapUtil.lua`
2. There is currently no StatusBar as a widget type. The last function in PixelUtil.lua file is commented out.
3. I suggest the following notation/template for naming an abstract class in cases where `@type table<key_type, abstract_class>` is used to define tables/objects: `MainTableName_Subtable`. Benefits:
   - It's clear to which it relates to or from which table it's taken
   - It indicates that object is just a subtable and you can work with it as with a regular table

   So, I've changed `RAID_CLASS_COLORS` type and used it for `SecondsFormatter.IntervalDescription`
4. Where possible, I've specified an argument as optional, name of return value, comments