### PR TITLE
Add classes for frames using backdrops

### DIFF
--- a/EmmyLua/API/SharedXML/Backdrop.lua
+++ b/EmmyLua/API/SharedXML/Backdrop.lua
@@ -1,0 +1,59 @@
+---@class backdropInfo
+---@field bgFile string
+---@field edgeFile string
+---@field tile boolean
+---@field tileSize integer
+---@field tileEdge boolean
+---@field edgeSize integer
+---@field insets backdropInsets
+
+---@class backdropInsets
+---@field left integer
+---@field right integer
+---@field top integer
+---@field bottom integer
+
+---@class BackdropTemplateMixin
+---[Documentation](https://wow.gamepedia.com/API_BackdropTemplateMixin)
+local BackdropTemplateMixin = {}
+
+function BackdropTemplateMixin:OnBackdropLoaded() end
+
+function BackdropTemplateMixin:OnBackdropSizeChanged() end
+
+function BackdropTemplateMixin:GetEdgeSize() end
+
+function BackdropTemplateMixin:SetupTextureCoordinates() end
+
+function BackdropTemplateMixin:SetupPieceVisuals(piece, setupInfo, pieceLayout) end
+
+function BackdropTemplateMixin:SetBorderBlendMode(blendMode) end
+
+---@param backdropInfo backdropInfo
+function BackdropTemplateMixin:HasBackdropInfo(backdropInfo) end
+
+function BackdropTemplateMixin:ClearBackdrop() end
+
+function BackdropTemplateMixin:ApplyBackdrop() end
+
+---@param backdropInfo backdropInfo
+function BackdropTemplateMixin:SetBackdrop(backdropInfo) end
+
+---@return backdropInfo
+function BackdropTemplateMixin:GetBackdrop() end
+
+function BackdropTemplateMixin:GetBackdropColor() end
+
+---@param r number
+---@param g number
+---@param b number
+---@param a? number
+function BackdropTemplateMixin:SetBackdropColor(r, g, b, a) end
+
+function BackdropTemplateMixin:GetBackdropBorderColor() end
+
+---@param r number
+---@param g number
+---@param b number
+---@param a? number
+function BackdropTemplateMixin:SetBackdropBorderColor(r, g, b, a) end


### PR DESCRIPTION
I noticed when a frame is created with the BackdropTemplateMixin all the backdrop items are not defined. This definition will allow the user to extend the frame class as needed to add in the proper doc info.

Before:
![image](https://user-images.githubusercontent.com/704321/161365859-1a91c689-a950-40b2-bfa1-c053f5061ef7.png)

After:
![image](https://user-images.githubusercontent.com/704321/161365898-0ff3840a-f879-46ca-bb12-5554a6e615e8.png)


The backdrop system does not have much documentation on Wowpedia outside of this one page https://wowpedia.fandom.com/wiki/BackdropTemplate I linked to it at the class level should I add links to it on each of the functions?