### PR TITLE
GH Action updates

### DIFF
--- a/.github/workflows/ReleaseBuilds.yml
+++ b/.github/workflows/ReleaseBuilds.yml
@@ -1,0 +1,42 @@
+name: Release
+
+# Controls when the workflow will run
+on:
+  push:
+    tags: ["**"]
+
+env:
+  CI: false #Without this, the build will fail. As Warnings in React will be treated as errors.
+  version: ${{ github.ref_name }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+
+      #Prep the codebase
+      - name: Variable Substitution
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: ./package.json
+
+      - run: npm i
+      - run: npm install -g vsce
+
+      - run: vsce package
+
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ./*.vsix

--- a/.github/workflows/TestBuilds.yml
+++ b/.github/workflows/TestBuilds.yml
@@ -1,12 +1,13 @@
 name: Release
 
+# Controls when the workflow will run
 on:
   push:
-    tags: ["**"]
+    branches: ['**']
 
 env:
   CI: false #Without this, the build will fail. As Warnings in React will be treated as errors.
-  version: ${{ github.ref_name }}
+  version: 0.${{ github.run_number }}.${{ github.run_attempt }}
 
 jobs:
   build:
@@ -27,13 +28,9 @@ jobs:
       - run: npm i
       - run: npm install -g vsce
 
-      - name: Release to GitHub
-        uses: softprops/action-gh-release
-        with:
-          files: ./ketho.wow-api-${{ github.ref_name }}.vsix
+      - run: vsce package
 
-      - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v1
+      - uses: actions/upload-artifact@v3
         with:
-          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
-          registryUrl: https://marketplace.visualstudio.com
+          name: build
+          path: ./*.vsix


### PR DESCRIPTION
Contains 2 actions files. 

- ReleaseBuilds.yml will run on tag, and publish to VS Marketplace & Github Releases
- TestBuild.yml will just run a build on commit to verify build is functioning so if something breaks you know about it sooner than later.  

Looks like 0.8.0 was uploaded to the marketplace and nothing else was so you can delete the tags 0.8.1 and up and reuse the numbers. 

Screenshot from my repo of them working:
![image](https://user-images.githubusercontent.com/704321/166173094-1c088207-3a5a-4399-bbfd-0716a8c43be7.png)
![image](https://user-images.githubusercontent.com/704321/166173270-4165fd3c-727e-41d2-ae85-9148bf033184.png)
