### PR TITLE
Add AceGUI

### DIFF
--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/AceGUI-3.0.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/AceGUI-3.0.lua
@@ -1,0 +1,218 @@
+---@meta
+---@alias AceGUILayoutType
+---|"Flow"
+---|"List"
+---|"Fill"
+
+---@alias AceGUIWidgetType
+---|"Button"
+---|"CheckBox"
+---|"ColorPicker"
+---|"DropDown"
+---|"EditBox"
+---|"Heading"
+---|"Icon"
+---|"InteractiveLabel"
+---|"Keybinding"
+---|"Label"
+---|"MultiLineEditBox"
+---|"Slider"
+
+---@alias AceGUIContainerType
+---|"DropdownGroup"
+---|"Frame"
+---|"InlineGroup"
+---|"ScrollFrame"
+---|"SimpleGroup"
+---|"TabGroup"
+---|"TreeGroup"
+---|"Window"
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-gui-3-0)
+---@class AceGUI-3.0
+local AceGUI = {}
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-gui-3-0#title-2)
+function AceGUI:ClearFocus() end
+
+---@param type AceGUIWidgetType|AceGUIContainerType
+---@return AceGUIWidget
+---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-gui-3-0#title-3)
+function AceGUI:Create(type) end
+
+---@param Name AceGUILayoutType
+---@return function
+---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-gui-3-0#title-4)
+function AceGUI:GetLayout(Name) end
+
+---@param type string
+---@return number
+---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-gui-3-0#title-5)
+function AceGUI:GetNextWidgetNum(type) end
+
+---@param type string
+---@return number
+---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-gui-3-0#title-6)
+function AceGUI:GetWidgetCount(type) end
+
+---@param type string
+---@return number
+---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-gui-3-0#title-7)
+function AceGUI:GetWidgetVersion(type) end
+
+---@param widget AceGUIWidget
+---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-gui-3-0#title-8)
+function AceGUI:RegisterAsContainer(widget) end
+
+---@param widget AceGUIWidget
+---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-gui-3-0#title-9)
+function AceGUI:RegisterAsWidget(widget) end
+
+---@param Name string
+---@param LayoutFunc function
+---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-gui-3-0#title-10)
+function AceGUI:RegisterLayout(Name, LayoutFunc) end
+
+---@param Name string
+---@param Constructor function
+---@param Version number
+---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-gui-3-0#title-11)
+function AceGUI:RegisterWidgetType(Name, Constructor, Version) end
+
+---@param widget AceGUIWidget
+---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-gui-3-0#title-12)
+function AceGUI:Release(widget) end
+
+---@param widget AceGUIWidget
+---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-gui-3-0#title-13)
+function AceGUI:SetFocus(widget) end
+
+---@meta
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets)
+---@class AceGUIWidget
+local AceGUIWidget = {}
+
+---@param name string
+---@param func function
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-1-1)
+function AceGUIWidget:SetCallback(name, func) end
+
+---@param width number
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-1-2)
+function AceGUIWidget:SetWidth(width) end
+
+---@param width number
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-1-3)
+function AceGUIWidget:SetRelativeWidth(width) end
+
+---@param height number
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-1-4)
+function AceGUIWidget:SetHeight(height) end
+
+---@return boolean
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-1-5)
+function AceGUIWidget:IsVisible() end
+
+---@return boolean
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-1-6)
+function AceGUIWidget:IsShown() end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-1-7)
+function AceGUIWidget:Release() end
+
+---@param point AnchorPoint
+---@param relativeTo Region|string
+---@param relativePoint string
+---@param ofsx? number
+---@param ofsy? number
+---@overload fun(self, point: AnchorPoint, relativeTo: Region|string, ofsx?: number, ofsy?: number)
+---@overload fun(self, point: AnchorPoint, ofsx?: number, ofsy?: number)
+---[Documentation](https://wowpedia.fandom.com/wiki/API_Region_SetPoint)
+function AceGUIWidget:SetPoint(point, relativeTo, relativePoint, ofsx, ofsy) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-1-9)
+function AceGUIWidget:ClearAllPoints() end
+
+---@return number
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-1-10)
+function AceGUIWidget:GetNumPoints() end
+
+---@param index number
+---@return string point
+---@return Region relativeTo
+---@return string relativePoint
+---@return number xOfs
+---@return number yOfs
+---[Documentation](https://wowpedia.fandom.com/wiki/API_Region_GetPoint)
+function AceGUIWidget:GetPoint(index) end
+
+---@return table
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-1-12)
+function AceGUIWidget:GetUserDataTable() end
+
+---@param key any
+---@param value any
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-1-13)
+function AceGUIWidget:SetUserData(key, value) end
+
+---@param key any
+---@return any
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-1-14)
+function AceGUIWidget:GetUserData(key) end
+
+---@param isFull boolean
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-1-15)
+function AceGUIWidget:SetFullHeight(isFull) end
+
+---@return boolean
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-1-16)
+function AceGUIWidget:IsFullHeight() end
+
+---@param isFull boolean
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-1-17)
+function AceGUIWidget:SetFullWidth(isFull) end
+
+---@return boolean
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-1-18)
+function AceGUIWidget:IsFullWidth() end
+
+---@param parent Region|string|nil
+function AceGUIWidget:SetParent(parent) end
+
+---@param name string
+function AceGUIWidget:Fire(name, ...) end
+
+---@return boolean
+function AceGUIWidget:IsReleasing() end
+
+---@meta
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets)
+---@class AceGUIContainer : AceGUIWidget
+local AceGUIContainer = {}
+
+---@param widget AceGUIWidget
+---@param beforeWidget? AceGUIWidget
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-3-1)
+function AceGUIContainer:AddChild(widget, beforeWidget) end
+
+---@param layout AceGUILayoutType
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-3-2)
+function AceGUIContainer:SetLayout(layout) end
+
+---@param flag boolean
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-3-3)
+function AceGUIContainer:SetAutoAdjustHeight(flag) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-3-4)
+function AceGUIContainer:ReleaseChildren() end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-3-5)
+function AceGUIContainer:DoLayout() end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-3-6)
+function AceGUIContainer:PauseLayout() end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-3-7)
+function AceGUIContainer:ResumeLayout() end
+
+function AceGUIContainer:PerformLayout() end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-DropDownGroup.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-DropDownGroup.lua
@@ -1,0 +1,23 @@
+---@meta
+---@class AceGUIDropdownGroup : AceGUIContainer
+local AceGUIDropdownGroup = {}
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-1-1)
+---@param text string
+function AceGUIDropdownGroup:SetTitle(text) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-1-1)
+---@param table table<unknown, string>
+---@param order? unknown[]
+function AceGUIDropdownGroup:SetGroupList(table, order) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-1-1)
+---@param key unknown
+function AceGUIDropdownGroup:SetGroup(key) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-1-1)
+---@param width number
+function AceGUIDropdownGroup:SetDropdownWidth(width) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-1-1)
+---@param table table
+function AceGUIDropdownGroup:SetStatusTable(table) end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-Frame.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-Frame.lua
@@ -1,0 +1,24 @@
+---@meta
+---@class AceGUIFrame : AceGUIContainer
+local AceGUIFrame = {}
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-2-1)
+---@param text string
+function AceGUIFrame:SetTitle(text) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-2-1)
+---@param text string
+function AceGUIFrame:SetStatusText(text) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-2-1)
+---@param table table
+function AceGUIFrame:SetStatusTable(table) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-2-1)
+function AceGUIFrame:ApplyStatus() end
+
+function AceGUIFrame:Show() end
+
+function AceGUIFrame:Hide() end
+
+---@param state boolean
+function AceGUIFrame:EnableResize(state) end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-InlineGroup.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-InlineGroup.lua
@@ -1,0 +1,6 @@
+---@meta
+---@class AceGUIInlineGroup : AceGUIContainer
+local AceGUIInlineGroup = {}
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-3-1)
+---@param text string
+function AceGUIInlineGroup:SetTitle(text) end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-ScrollFrame.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-ScrollFrame.lua
@@ -1,0 +1,13 @@
+---@meta
+---@class AceGUIScrollFrame : AceGUIContainer
+local AceGUIScrollFrame = {}
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-4-1)
+---@param value number
+function AceGUIScrollFrame:SetScroll(value) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-4-1)
+---@param table table
+function AceGUIScrollFrame:SetStatusTable(table) end
+
+---@param value number
+function AceGUIScrollFrame:MoveScroll(value) end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-SimpleGroup.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-SimpleGroup.lua
@@ -1,0 +1,3 @@
+---@meta
+---@class AceGUISimpleGroup : AceGUIContainer
+local AceGUISimpleGroup = {}

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-TabGroup.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-TabGroup.lua
@@ -1,0 +1,24 @@
+---@meta
+---@class AceGUITabGroup : AceGUIContainer
+local AceGUITabGroup = {}
+
+---@class AceGUITabGroupTab
+---@field value unknown
+---@field text string
+---@field disabled? boolean
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-6-1)
+---@param text string
+function AceGUITabGroup:SetTitle(text) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-6-1)
+---@param table AceGUITabGroupTab[]
+function AceGUITabGroup:SetTabs(table) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-6-1)
+---@param key string
+function AceGUITabGroup:SelectTab(key) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-6-1)
+---@param table table
+function AceGUITabGroup:SetStatusTable(table) end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
@@ -1,0 +1,22 @@
+---@meta
+---@class AceGUITreeGroup : AceGUIContainer
+local AceGUITreeGroup = {}
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-7-1)
+---@param tree table
+function AceGUITreeGroup:SetTree(tree) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-7-1)
+---@param ... string
+function AceGUITreeGroup:SelectByPath(...) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-7-1)
+---@param uniquevalue unknown
+function AceGUITreeGroup:SelectByValue(uniquevalue) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-7-1)
+---@param flag boolean
+function AceGUITreeGroup:EnableButtonTooltips(flag) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-7-1)
+---@param table table
+function AceGUITreeGroup:SetStatusTable(table) end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-Window.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-Window.lua
@@ -1,0 +1,14 @@
+---@meta
+---@class AceGUIWindow
+local AceGUIWindow = {}
+---@param title string
+function AceGUIWindow:SetTitle(title) end
+
+---@param status table
+function AceGUIWindow:SetStatusTable(status) end
+
+---@param text string
+function AceGUIWindow:SetStatusText(text) end
+
+---@param state boolean
+function AceGUIWindow:EnableResize(state) end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Button.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Button.lua
@@ -1,0 +1,13 @@
+---@meta
+---@class AceGUIButton : AceGUIWidget
+local AceGUIButton = {}
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-1-1)
+---@param text string
+function AceGUIButton:SetText(text) end
+
+---@param autoWidth boolean
+function AceGUIButton:SetAutoWidth(autoWidth) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-1-1)
+---@param flag boolean
+function AceGUIButton:SetDisabled(flag) end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-CheckBox.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-CheckBox.lua
@@ -1,0 +1,38 @@
+---@meta
+---@class AceGUICheckBox : AceGUIWidget
+local AceGUICheckBox = {}
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-2-1)
+---@param flag boolean|nil
+function AceGUICheckBox:SetValue(flag) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-2-1)
+---@return boolean|nil
+function AceGUICheckBox:GetValue() end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-2-1)
+---@param type "radio"|"checkbox"
+function AceGUICheckBox:SetType(type) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-2-1)
+function AceGUICheckBox:ToggleChecked() end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-2-1)
+---@param text string
+function AceGUICheckBox:SetLabel(text) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-2-1)
+---@param state boolean
+function AceGUICheckBox:SetTriState(state) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-2-1)
+---@param flag boolean
+function AceGUICheckBox:SetDisabled(flag) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-2-1)
+---@param description string
+function AceGUICheckBox:SetDescription(description) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-2-1)
+---@param path string|number
+---@param ...? unknown
+function AceGUICheckBox:SetImage(path, ...) end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-ColorPicker.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-ColorPicker.lua
@@ -1,0 +1,21 @@
+---@meta
+---@class AceGUIColorPicker : AceGUIWidget
+local AceGUIColorPicker = {}
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-3-1)
+---@param r number
+---@param g number
+---@param b number
+---@param a number
+function AceGUIColorPicker:SetColor(r, g, b, a) end
+
+--- ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-3-1)
+---@param text string
+function AceGUIColorPicker:SetLabel(text) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-3-1)
+---@param flag boolean
+function AceGUIColorPicker:SetHasAlpha(flag) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-3-1)
+---@param flag boolean
+function AceGUIColorPicker:SetDisabled(flag) end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-DropDown.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-DropDown.lua
@@ -1,0 +1,54 @@
+---@meta
+---@class AceGUIDropdown : AceGUIWidget
+local AceGUIDropdown = {}
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-4-1)
+---@param key unknown
+function AceGUIDropdown:SetValue(key) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-4-1)
+---@param table table<unknown, string>
+---@param order? unknown[]
+function AceGUIDropdown:SetList(table, order) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-4-1)
+---@param text string
+function AceGUIDropdown:SetText(text) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-4-1)
+---@param text string
+function AceGUIDropdown:SetLabel(text) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-4-1)
+---@param key unknown
+---@param value string
+function AceGUIDropdown:AddItem(key, value) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-4-1)
+---@param flag boolean
+function AceGUIDropdown:SetMultiselect(flag) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-4-1)
+---@return boolean
+function AceGUIDropdown:GetMultiselect() end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-4-1)
+---@param key unknown
+---@param value string
+function AceGUIDropdown:SetItemValue(key, value) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-4-1)
+---@param key unknown
+---@param flag boolean
+function AceGUIDropdown:SetItemDisabled(key, flag) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-4-1)
+---@param flag boolean
+function AceGUIDropdown:SetDisabled(flag) end
+
+function AceGUIDropdown:ClearFocus() end
+
+---@return unknown
+function AceGUIDropdown:GetValue() end
+
+---@param width number
+function AceGUIDropdown:SetPulloutWidth(width) end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-EditBox.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-EditBox.lua
@@ -1,0 +1,36 @@
+---@meta
+---@class AceGUIEditBox : AceGUIWidget
+local AceGUIEditBox = {}
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-5-1)
+---@param text string
+function AceGUIEditBox:SetText(text) end
+
+--- ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-5-1)
+---@return string
+function AceGUIEditBox:GetText() end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-5-1)
+---@param text string
+function AceGUIEditBox:SetLabel(text) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-5-1)
+---@param flag boolean
+function AceGUIEditBox:SetDisabled(flag) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-5-1)
+---@param flag boolean
+function AceGUIEditBox:DisableButton(flag) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-5-1)
+---@param num number
+function AceGUIEditBox:SetMaxLetters(num) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-5-1)
+function AceGUIEditBox:SetFocus() end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-5-1)
+---@param from number
+---@param to number
+function AceGUIEditBox:HighlightText(from, to) end
+
+function AceGUIEditBox:ClearFocus() end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Heading.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Heading.lua
@@ -1,0 +1,6 @@
+---@meta
+---@class AceGUIHeading : AceGUIWidget
+local AceGUIHeading = {}
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-6-1)
+---@param text string
+function AceGUIHeading:SetText(text) end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Icon.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Icon.lua
@@ -1,0 +1,19 @@
+---@meta
+---@class AceGUIIcon : AceGUIWidget
+local AceGUIIcon = {}
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-7-1)
+---@param image string|number
+---@param ...? unknown
+function AceGUIIcon:SetImage(image, ...) end
+
+--- ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-7-1)
+---@param width number
+---@param height number
+function AceGUIIcon:SetImageSize(width, height) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-7-1)
+---@param text string
+function AceGUIIcon:SetLabel(text) end
+
+---@param disabled boolean
+function AceGUIIcon:SetDisabled(disabled) end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-InteractiveLabel.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-InteractiveLabel.lua
@@ -1,0 +1,49 @@
+---@meta
+---@class AceGUIInteractiveLabel : AceGUIWidget
+local AceGUIInteractiveLabel = {}
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-8-1)
+---@param text string
+function AceGUIInteractiveLabel:SetText(text) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-8-1)
+---@param r number
+---@param g number
+---@param b number
+function AceGUIInteractiveLabel:SetColor(r, g, b) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-8-1)
+---@param font string
+---@param height number
+---@param flags string?
+function AceGUIInteractiveLabel:SetFont(font, height, flags) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-8-1)
+---@param font? Font|string
+function AceGUIInteractiveLabel:SetFontObject(font) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-8-1)
+---@param image string|number
+---@param ...? unknown
+function AceGUIInteractiveLabel:SetImage(image, ...) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-8-1)
+---@param width number
+---@param height number
+function AceGUIInteractiveLabel:SetImageSize(width, height) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-8-1)
+---@param ... unknown
+function AceGUIInteractiveLabel:SetHighlight(...) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-8-1)
+---@param ... unknown
+function AceGUIInteractiveLabel:SetHighlightTexCoord(...) end
+
+---@param disabled boolean
+function AceGUIInteractiveLabel:SetDisabled(disabled) end
+
+---@param justifyH "LEFT"|"RIGHT"|"CENTER"
+function AceGUIInteractiveLabel:SetJustifyH(justifyH) end
+
+---@param justifyV "TOP"|"BOTTOM"|"MIDDLE"
+function AceGUIInteractiveLabel:SetJustifyV(justifyV) end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Keybinding.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Keybinding.lua
@@ -1,0 +1,18 @@
+---@meta
+---@class AceGUIKeybinding : AceGUIWidget
+local AceGUIKeybinding = {}
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-9-1)
+---@param key string
+function AceGUIKeybinding:SetKey(key) end
+
+--- ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-9-1)
+---@return string
+function AceGUIKeybinding:GetKey() end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-9-1)
+---@param text string
+function AceGUIKeybinding:SetLabel(text) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-9-1)
+---@param flag boolean
+function AceGUIKeybinding:SetDisabled(flag) end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Label.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Label.lua
@@ -1,0 +1,38 @@
+---@meta
+---@class AceGUILabel : AceGUIWidget
+local AceGUILabel = {}
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-10-1)
+---@param text string
+function AceGUILabel:SetText(text) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-10-1)
+---@param r number
+---@param g number
+---@param b number
+function AceGUILabel:SetColor(r, g, b) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-10-1)
+---@param font string
+---@param height number
+---@param flags string?
+function AceGUILabel:SetFont(font, height, flags) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-10-1)
+---@param font? Font|string
+function AceGUILabel:SetFontObject(font) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-10-1)
+---@param image string|number
+---@param ... unknown
+function AceGUILabel:SetImage(image, ...) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-10-1)
+---@param width number
+---@param height number
+function AceGUILabel:SetImageSize(width, height) end
+
+---@param justifyH "LEFT"|"RIGHT"|"CENTER"
+function AceGUILabel:SetJustifyH(justifyH) end
+
+---@param justifyV "TOP"|"BOTTOM"|"MIDDLE"
+function AceGUILabel:SetJustifyV(justifyV) end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-MultiLineEditBox.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-MultiLineEditBox.lua
@@ -1,0 +1,46 @@
+---@meta
+---@class AceGUIMultiLineEditBox : AceGUIWidget
+local AceGUIMultiLineEditBox = {}
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-11-1)
+---@param text string
+function AceGUIMultiLineEditBox:SetText(text) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-11-1)
+---@return string
+function AceGUIMultiLineEditBox:GetText() end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-11-1)
+---@param text string
+function AceGUIMultiLineEditBox:SetLabel(text) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-11-1)
+---@param num number
+function AceGUIMultiLineEditBox:SetNumLines(num) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-11-1)
+---@param flag boolean
+function AceGUIMultiLineEditBox:SetDisabled(flag) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-11-1)
+---@param num number
+function AceGUIMultiLineEditBox:SetMaxLetters(num) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-11-1)
+---@param flag boolean
+function AceGUIMultiLineEditBox:DisableButton(flag) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-11-1)
+function AceGUIMultiLineEditBox:SetFocus() end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-11-1)
+---@param from number
+---@param to number
+function AceGUIMultiLineEditBox:HighlightText(from, to) end
+
+function AceGUIMultiLineEditBox:ClearFocus() end
+
+---@return number
+function AceGUIMultiLineEditBox:GetCursorPosition() end
+
+---@param position number
+function AceGUIMultiLineEditBox:SetCursorPosition(position) end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Slider.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Slider.lua
@@ -1,0 +1,28 @@
+---@meta
+---@class AceGUISlider : AceGUIWidget
+local AceGUISlider = {}
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-12-1)
+---@param value number
+function AceGUISlider:SetValue(value) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-12-1)
+---@return number
+function AceGUISlider:GetValue() end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-12-1)
+---@param min? number
+---@param max? number
+---@param step? number
+function AceGUISlider:SetSliderValues(min, max, step) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-12-1)
+---@param flag boolean
+function AceGUISlider:SetIsPercent(flag) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-12-1)
+---@param text string
+function AceGUISlider:SetLabel(text) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-12-1)
+---@param flag boolean
+function AceGUISlider:SetDisabled(flag) end


### PR DESCRIPTION
As far as I can tell, there's no way of applying a prefix to the name of a generic for the return type, so I wasn't able to figure out any way of getting `AceGUI:Create` to return the proper widget type. It would need to prefix the first parameter with `AceGUI` and use that as the return type. Type definitions are included for all widgets for manual type casting.