### PR TITLE
Update `LibStub:NewLibrary` return value

### DIFF
--- a/EmmyLua/API/Libraries/LibStub/LibStub.lua
+++ b/EmmyLua/API/Libraries/LibStub/LibStub.lua
@@ -2,8 +2,10 @@
 ---[Documentation](https://www.wowace.com/projects/libstub)
 LibStub = {}
 
----@param major string
+---@generic T
+---@param major `T`
 ---@param minor number
+---@return T library
 function LibStub:NewLibrary(major, minor) end
 
 ---@generic T

--- a/EmmyLua/API/Libraries/LibStub/LibStub.lua
+++ b/EmmyLua/API/Libraries/LibStub/LibStub.lua
@@ -6,6 +6,7 @@ LibStub = {}
 ---@param major `T`
 ---@param minor number
 ---@return T library
+---@return number? oldMinor
 function LibStub:NewLibrary(major, minor) end
 
 ---@generic T


### PR DESCRIPTION
Currently, `LibStub:NewLibrary` has no return value. It now returns a value of generic type `T`.

Instead of having to manully specify a `@class` to the value, it's automatically inferred by whatever string is given as major. So: `LibStub:NewLibrary("MyLib-1.0")` returns a value of type `MyLib-1.0`.