### PR TITLE
Update `GetPvpTalentInfoByID`

### DIFF
--- a/EmmyLua/API/GlobalAPI/API3.lua
+++ b/EmmyLua/API/GlobalAPI/API3.lua
@@ -1253,7 +1253,7 @@ function GetPvpPowerHealing() end
 
 ---[Documentation](https://wowpedia.fandom.com/wiki/API_GetPvpTalentInfoByID)
 ---@param talentID number
----@param specGroupIndex number
+---@param specGroupIndex? number
 ---@param isInspect? boolean
 ---@param inspectUnit? UnitId
 ---@return number talentID


### PR DESCRIPTION
`specGroupIndex` is optional, see https://wowpedia.fandom.com/wiki/API_GetPvpTalentInfoByID

Probably have to run your parser again though?