### PR TITLE
AceBucket-3.0: Fix the event parameter for for RegisterBucketEvent an…

### DIFF
--- a/EmmyLua/API/Libraries/Ace3/AceBucket-3.0.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceBucket-3.0.lua
@@ -3,7 +3,7 @@
 ---@class AceBucket-3.0
 local AceBucket = {}
 
----@param event WowEvent The event to register for
+---@param event WowEvent|WowEvent[] The event to listen for, or a table of events.
 ---@param interval number The Bucket interval (burst interval)
 ---@param callback function The callback function to call when the event is triggered (funcref or method, defaults to a method with the event name)
 --- ---
@@ -11,7 +11,7 @@ local AceBucket = {}
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-bucket-3-0#title-2)
 function AceBucket:RegisterBucketEvent(event, interval, callback) end
 
----@param message string The message to listen for, or a table of messages.
+---@param message string|string[] The message to listen for, or a table of messages.
 ---@param interval number The Bucket interval (burst interval)
 ---@param callback function The callback function, either as a function reference, or a string pointing to a method of the addon object.
 --- ---


### PR DESCRIPTION
…d the message parameter for RegisterBucketMessage to correctly allow for the use of tables of strings.