### PR TITLE
Fix return type for AceDBOptions:GetOptionsTable

### DIFF
--- a/EmmyLua/API/Libraries/Ace3/AceDBOptions-3.0.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceDBOptions-3.0.lua
@@ -18,6 +18,6 @@ Usage:
 ---@paramsig db, noDefaultProfiles
 ---@param db AceDBObject-3.0 The database object to create the options table for.
 ---@param noDefaultProfiles? boolean
----@return AceConfigOptionsTable # The options table to be used in AceConfig-3.0
+---@return AceConfig.OptionsTable optionsTable The options table to be used in AceConfig-3.0
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-dboptions-3-0#title-1)
 function AceDBOptions:GetOptionsTable(db, noDefaultProfiles) end

--- a/EmmyLua/API/Libraries/Ace3/AceDBOptions-3.0.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceDBOptions-3.0.lua
@@ -1,7 +1,10 @@
 ---@meta
+
+-- ----------------------------------------------------------------------------
+-- AceDBOptions-3.0
+-- ----------------------------------------------------------------------------
 ---@class AceDBOptions-3.0
 local AceDBOptions = {}
-
 
 --[[ 
 Get/Create a option table that you can use in your addon to control the profiles of AceDB-3.0.


### PR DESCRIPTION
The type was manually renamed in another PR.