### PR TITLE
Make AceGUI HighlighText parameters optional

### DIFF
--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-EditBox.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-EditBox.lua
@@ -29,8 +29,8 @@ function AceGUIEditBox:SetMaxLetters(num) end
 function AceGUIEditBox:SetFocus() end
 
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-5-1)
----@param from number
----@param to number
+---@param from? number
+---@param to? number
 function AceGUIEditBox:HighlightText(from, to) end
 
 function AceGUIEditBox:ClearFocus() end

--- a/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-MultiLineEditBox.lua
+++ b/EmmyLua/API/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-MultiLineEditBox.lua
@@ -33,8 +33,8 @@ function AceGUIMultiLineEditBox:DisableButton(flag) end
 function AceGUIMultiLineEditBox:SetFocus() end
 
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-11-1)
----@param from number
----@param to number
+---@param from? number
+---@param to? number
 function AceGUIMultiLineEditBox:HighlightText(from, to) end
 
 function AceGUIMultiLineEditBox:ClearFocus() end


### PR DESCRIPTION
Per the documentation on those functions:
> Highlight the text in the editbox (see Blizzard EditBox Widget documentation for details)

From https://wowpedia.fandom.com/wiki/API_EditBox_HighlightText
> Leaving out both parameters, as in `EditBox:HighlightText()`, will highlight the entire EditBox content.
