### PR TITLE
Update array before updating config

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,7 +48,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	setExternalLibrary("API", true, library);
 	const loadFrameXML = vscode.workspace.getConfiguration("wowAPI").get("emmyLua.loadFrameXML");
-	setExternalLibrary("Optional", loadFrameXML, library);
+	setExternalLibrary("Optional", loadFrameXML ? true : false, library);
 
 	config.update("workspace.library", library, true);
 


### PR DESCRIPTION
`Lua.workspace.library` was being updated but immediately overwritten on the second call to `setExternalLibrary`. After some debugging, it seems like `vscode.workspace.getConfiguration` does not reload everything from the config on the second time it is called.

There is some interesting magic going on here: https://github.com/microsoft/vscode/blob/230a6266ebc8e092521a949ed159d8be23e1b1b2/src/vs/workbench/api/common/extHostConfiguration.ts#L186

Related to issue #100 - please review with scrutiny, as I am not an experienced extension developer..