### PR TITLE
Fix UnitAura documentation

### DIFF
--- a/EmmyLua/API/GlobalAPI/API5.lua
+++ b/EmmyLua/API/GlobalAPI/API5.lua
@@ -55,7 +55,7 @@ function UnitAttackSpeed(unit) end
 ---[Documentation](https://wowpedia.fandom.com/wiki/API_UnitAura)
 ---@param unit UnitId
 ---@param index number
----@param filter? number
+---@param filter? string
 ---@return string name
 ---@return number icon
 ---@return number count
@@ -77,7 +77,7 @@ function UnitAura(unit, index, filter) end
 ---[Documentation](https://wowpedia.fandom.com/wiki/API_UnitAura)
 ---@param unit UnitId
 ---@param index number
----@param filter? number
+---@param filter? string
 ---@return string name
 ---@return number icon
 ---@return number count
@@ -99,7 +99,7 @@ function UnitBuff(unit, index, filter) end
 ---[Documentation](https://wowpedia.fandom.com/wiki/API_UnitAura)
 ---@param unit UnitId
 ---@param index number
----@param filter? number
+---@param filter? string
 ---@return string name
 ---@return number icon
 ---@return number count

--- a/EmmyLua/API/GlobalAPI/API5.lua
+++ b/EmmyLua/API/GlobalAPI/API5.lua
@@ -62,7 +62,7 @@ function UnitAttackSpeed(unit) end
 ---@return string? dispelType
 ---@return number duration
 ---@return number expirationTime
----@return string source
+---@return UnitId source
 ---@return boolean isStealable
 ---@return boolean nameplateShowPersonal
 ---@return number spellId
@@ -84,7 +84,7 @@ function UnitAura(unit, index, filter) end
 ---@return string? dispelType
 ---@return number duration
 ---@return number expirationTime
----@return string source
+---@return UnitId source
 ---@return boolean isStealable
 ---@return boolean nameplateShowPersonal
 ---@return number spellId
@@ -106,7 +106,7 @@ function UnitBuff(unit, index, filter) end
 ---@return string? dispelType
 ---@return number duration
 ---@return number expirationTime
----@return string source
+---@return UnitId source
 ---@return boolean isStealable
 ---@return boolean nameplateShowPersonal
 ---@return number spellId


### PR DESCRIPTION
From this page https://wowpedia.fandom.com/wiki/API_UnitAura `filter` is a string instead of number, and source is a `UnitId`