### PR TITLE
Add Evoker to classfile union

### DIFF
--- a/EmmyLua/API/Type/Type.lua
+++ b/EmmyLua/API/Type/Type.lua
@@ -30,6 +30,7 @@
 ---|"MONK"        # 10
 ---|"DRUID"       # 11
 ---|"DEMONHUNTER" # 12
+---|"EVOKER"      # 13
 
 ---@alias HyperlinkType -- #41
 ---|"achievement"


### PR DESCRIPTION
The classfile type seems to have gotten a bit out-of-sync with the Wiki; https://warcraft.wiki.gg/wiki/ClassId lists "EVOKER" but the extension doesn't.