### PR TITLE
File IDs are integers

### DIFF
--- a/EmmyLua/API/Type/BlizzardType.lua
+++ b/EmmyLua/API/Type/BlizzardType.lua
@@ -5,7 +5,7 @@
 ---@alias ClubId string
 ---@alias ClubInvitationId string
 ---@alias ClubStreamId string
----@alias fileID string
+---@alias fileID integer
 ---@alias GarrisonFollower string
 ---@alias HTMLTextType string
 ---@alias ItemInfo number|string


### PR DESCRIPTION
The fileID type should probably be an integer under the hood, as that's what the API _really_ uses for both return values and structure fields.

There's a chance this might break some stuff - specifically, I'm wondering if we've documented some API parameters as being "fileIDs" when in fact they can be either a file ID or a file name.