### PR TITLE
Add option autoAddGlobals

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
 						"zhTW"
 					],
 					"markdownDescription": "Sets the GlobalStrings locale for code completion and hover."
+				},
+				"wowAPI.autoAddGlobals": {
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "Automatically add known WoW globals to Lua.diagnostics.globals."
 				}
 			}
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,6 +111,9 @@ export async function activate(context: vscode.ExtensionContext) {
 	const diag_globals: string[] = config.get("diagnostics.globals")!;
 
 	vscode.languages.onDidChangeDiagnostics((event: vscode.DiagnosticChangeEvent) => {
+		if (!vscode.workspace.getConfiguration("wowAPI").get("autoAddGlobals")) {
+			return;
+		}
 		let hasUpdate = false;
 		event.uris.forEach(function(uri) {
 			let diags = vscode.languages.getDiagnostics(uri);


### PR DESCRIPTION
This option controls whether the extension attempts to automatically manage the diagnostics.globals setting.