### PR TITLE
Update AceGUI documentation

### DIFF
--- a/Annotations/Libraries/Ace3/AceGUI-3.0/AceGUI-3.0.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/AceGUI-3.0.lua
@@ -6,6 +6,7 @@
 ---|"Table"
 
 ---@alias AceGUIWidgetType
+---|"BlizOptionsGroup"
 ---|"Button"
 ---|"CheckBox"
 ---|"ColorPicker"

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/AceGUI-3.0.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/AceGUI-3.0.lua
@@ -3,6 +3,7 @@
 ---|"Flow"
 ---|"List"
 ---|"Fill"
+---|"Table"
 
 ---@alias AceGUIWidgetType
 ---|"Button"

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/AceGUI-3.0.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/AceGUI-3.0.lua
@@ -92,6 +92,12 @@ function AceGUI:SetFocus(widget) end
 ---@meta _
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets)
 ---@class AceGUIWidget
+---@field public type string
+---@field protected frame Frame
+---@field protected userdata table
+---@field protected events table<string,function>
+---@field protected width? string|number
+---@field protected height? string|number
 local AceGUIWidget = {}
 
 ---@param name string
@@ -190,6 +196,8 @@ function AceGUIWidget:IsReleasing() end
 ---@meta _
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets)
 ---@class AceGUIContainer : AceGUIWidget
+---@field protected children AceGUIWidget[]
+---@field protected content Frame
 local AceGUIContainer = {}
 
 ---@param widget AceGUIWidget

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/AceGUI-3.0.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/AceGUI-3.0.lua
@@ -32,6 +32,7 @@
 
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-gui-3-0)
 ---@class AceGUI-3.0
+---@field tooltip GameTooltip
 local AceGUI = {}
 
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-gui-3-0#title-2)

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-BlizOptionsGroup.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-BlizOptionsGroup.lua
@@ -1,0 +1,31 @@
+---@meta _
+---@class AceGUIBlizOptionsGroup : AceGUIContainer
+---@field protected label FontString
+local AceGUIBlizOptionsGroup = {}
+
+---@param text string
+function AceGUIBlizOptionsGroup:SetTitle(text) end
+
+---@param name string
+---@param parent unknown
+function AceGUIBlizOptionsGroup:SetName(name, parent) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-1-1)
+---@param key unknown
+function AceGUIBlizOptionsGroup:SetGroup(key) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-1-1)
+---@param width number
+function AceGUIBlizOptionsGroup:SetDropdownWidth(width) end
+
+---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-1-1)
+---@param table table
+function AceGUIBlizOptionsGroup:SetStatusTable(table) end
+
+---@protected
+---@param width integer
+function AceGUIBlizOptionsGroup:OnWidthSet(width) end
+
+---@protected
+---@param height integer
+function AceGUIBlizOptionsGroup:OnHeightSet(height) end

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-DropDownGroup.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-DropDownGroup.lua
@@ -1,6 +1,12 @@
 ---@meta _
 ---@class AceGUIDropdownGroup : AceGUIContainer
+---@field protected localstatus table
+---@field protected status? table
+---@field protected titletext FontString
+---@field protected dropdown AceGUIDropdown
+---@field protected border Frame|BackdropTemplate
 local AceGUIDropdownGroup = {}
+
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-1-1)
 ---@param text string
 function AceGUIDropdownGroup:SetTitle(text) end
@@ -21,3 +27,22 @@ function AceGUIDropdownGroup:SetDropdownWidth(width) end
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-1-1)
 ---@param table table
 function AceGUIDropdownGroup:SetStatusTable(table) end
+
+---@protected
+---@param width integer
+function AceGUIDropdownGroup:OnWidthSet(width) end
+
+---@protected
+---@param height integer
+function AceGUIDropdownGroup:OnHeightSet(height) end
+
+---@protected
+---@param width integer
+---@param height integer
+function AceGUIDropdownGroup:LayoutFinished(width, height) end
+
+---@class AceGUIDropdownGroupStatus
+---@field selected? unknown
+---@field left? number
+---@field width? number
+---@field height? number

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-Frame.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-Frame.lua
@@ -1,6 +1,16 @@
 ---@meta _
 ---@class AceGUIFrame : AceGUIContainer
+---@field protected localstatus AceGUIFrameStatus
+---@field protected status? AceGUIFrameStatus
+---@field protected titletext FontString
+---@field protected statustext FontString
+---@field protected titlebg Texture
+---@field protected sizer_se Frame
+---@field protected sizer_s Frame
+---@field protected sizer_e Frame
+---@field protected frame Frame|BackdropTemplate
 local AceGUIFrame = {}
+
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-2-1)
 ---@param text string
 function AceGUIFrame:SetTitle(text) end
@@ -22,3 +32,17 @@ function AceGUIFrame:Hide() end
 
 ---@param state boolean
 function AceGUIFrame:EnableResize(state) end
+
+---@protected
+---@param width integer
+function AceGUIFrame:OnWidthSet(width) end
+
+---@protected
+---@param height integer
+function AceGUIFrame:OnHeightSet(height) end
+
+---@class AceGUIFrameStatus
+---@field top? number
+---@field left? number
+---@field width? number
+---@field height? number

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-InlineGroup.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-InlineGroup.lua
@@ -1,6 +1,21 @@
 ---@meta _
 ---@class AceGUIInlineGroup : AceGUIContainer
+---@field protected titletext FontString
 local AceGUIInlineGroup = {}
+
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-3-1)
 ---@param text string
 function AceGUIInlineGroup:SetTitle(text) end
+
+---@protected
+---@param width integer
+function AceGUIInlineGroup:OnWidthSet(width) end
+
+---@protected
+---@param height integer
+function AceGUIInlineGroup:OnHeightSet(height) end
+
+---@protected
+---@param width integer
+---@param height integer
+function AceGUIInlineGroup:LayoutFinished(width, height) end

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-ScrollFrame.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-ScrollFrame.lua
@@ -1,6 +1,11 @@
 ---@meta _
 ---@class AceGUIScrollFrame : AceGUIContainer
+---@field protected localstatus AceGUIScrollFrameStatus
+---@field protected status? AceGUIScrollFrameStatus
+---@field protected scrollframe ScrollFrame
+---@field protected scrollbar Slider
 local AceGUIScrollFrame = {}
+
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-4-1)
 ---@param value number
 function AceGUIScrollFrame:SetScroll(value) end
@@ -11,3 +16,23 @@ function AceGUIScrollFrame:SetStatusTable(table) end
 
 ---@param value number
 function AceGUIScrollFrame:MoveScroll(value) end
+
+---@protected
+function AceGUIScrollFrame:FixScroll() end
+
+---@protected
+---@param width integer
+function AceGUIScrollFrame:OnWidthSet(width) end
+
+---@protected
+---@param height integer
+function AceGUIScrollFrame:OnHeightSet(height) end
+
+---@protected
+---@param width integer
+---@param height integer
+function AceGUIScrollFrame:LayoutFinished(width, height) end
+
+---@class AceGUIScrollFrameStatus
+---@field scrollvalue number
+---@field offset? integer

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-SimpleGroup.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-SimpleGroup.lua
@@ -1,3 +1,16 @@
 ---@meta _
 ---@class AceGUISimpleGroup : AceGUIContainer
 local AceGUISimpleGroup = {}
+
+---@protected
+---@param width integer
+function AceGUISimpleGroup:OnWidthSet(width) end
+
+---@protected
+---@param height integer
+function AceGUISimpleGroup:OnHeightSet(height) end
+
+---@protected
+---@param width integer
+---@param height integer
+function AceGUISimpleGroup:LayoutFinished(width, height) end

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-TabGroup.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-TabGroup.lua
@@ -1,5 +1,14 @@
 ---@meta _
 ---@class AceGUITabGroup : AceGUIContainer
+---@field protected num integer
+---@field protected localstatus AceGUITabGroupStatus
+---@field protected status? AceGUITabGroupStatus
+---@field protected alignoffset number
+---@field protected titletext FontString
+---@field protected border Frame|BackdropTemplate
+---@field protected borderoffset number
+---@field protected tabs Button[]
+---@field protected tablist AceGUITabGroupTab[]
 local AceGUITabGroup = {}
 
 ---@class AceGUITabGroupTab
@@ -22,3 +31,27 @@ function AceGUITabGroup:SelectTab(key) end
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-6-1)
 ---@param table table
 function AceGUITabGroup:SetStatusTable(table) end
+
+---@protected
+function AceGUITabGroup:BuildTabs() end
+
+---@protected
+---@param id integer
+---@return Button
+function AceGUITabGroup:CreateTab(id) end
+
+---@protected
+---@param width integer
+function AceGUITabGroup:OnWidthSet(width) end
+
+---@protected
+---@param height integer
+function AceGUITabGroup:OnHeightSet(height) end
+
+---@protected
+---@param width integer
+---@param height integer
+function AceGUITabGroup:LayoutFinished(width, height) end
+
+---@class AceGUITabGroupStatus
+---@field selected? string

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
@@ -1,16 +1,39 @@
 ---@meta _
 ---@class AceGUITreeGroup : AceGUIContainer
+---@field protected lines AceGUITreeGroupLine[]
+---@field protected buttons Button[]
+---@field protected localstatus AceGUITreeGroupStatus
+---@field protected status? AceGUITreeGroupStatus
+---@field protected filter boolean
+---@field protected treeframe Frame|BackdropTemplate
+---@field protected dragger Frame|BackdropTemplate
+---@field protected scrollbar Slider
+---@field protected border Frame|BackdropTemplate
+---@field protected enabletooltips boolean
 local AceGUITreeGroup = {}
+
+---@protected
+---@return Button
+function AceGUITreeGroup:CreateButton() end
+
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-7-1)
 ---@param tree table
-function AceGUITreeGroup:SetTree(tree) end
+---@param filter? boolean
+function AceGUITreeGroup:SetTree(tree, filter) end
+
+---@param value string
+function AceGUITreeGroup:SetSelected(value) end
+
+---@param uniquevalue string
+---@param ... string
+function AceGUITreeGroup:Select(uniquevalue, ...) end
 
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-7-1)
 ---@param ... string
 function AceGUITreeGroup:SelectByPath(...) end
 
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-7-1)
----@param uniquevalue unknown
+---@param uniquevalue string
 function AceGUITreeGroup:SelectByValue(uniquevalue) end
 
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-7-1)
@@ -20,3 +43,59 @@ function AceGUITreeGroup:EnableButtonTooltips(flag) end
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-4-7-1)
 ---@param table table
 function AceGUITreeGroup:SetStatusTable(table) end
+
+---@param show boolean
+function AceGUITreeGroup:ShowScroll(show) end
+
+---@param treewidth integer
+---@param resizable boolean
+function AceGUITreeGroup:SetTreeWidth(treewidth, resizable) end
+
+---@return integer
+function AceGUITreeGroup:GetTreeWidth() end
+
+---@protected
+---@param tree table
+---@param level? integer
+---@param parent? AceGUITreeGroupLine
+function AceGUITreeGroup:BuildLevel(tree, level, parent) end
+
+---@protected
+---@param scrollToSelection? boolean
+---@param fromOnUpdate? boolean
+function AceGUITreeGroup:RefreshTree(scrollToSelection, fromOnUpdate) end
+
+---@protected
+---@param width integer
+function AceGUITreeGroup:OnWidthSet(width) end
+
+---@protected
+---@param height integer
+function AceGUITreeGroup:OnHeightSet(height) end
+
+---@protected
+---@param width integer
+---@param height integer
+function AceGUITreeGroup:LayoutFinished(width, height) end
+
+---@class AceGUITreeGroupStatus
+---@field groups table
+---@field scrollvalue number
+---@field scrollToSelection? boolean
+---@field fullwidth? boolean
+---@field treewidth? integer
+---@field treesizable? boolean
+---@field selected? string
+
+---@class AceGUITreeGroupLine
+---@field value any
+---@field text string
+---@field icon? string|integer
+---@field iconCoords? number[]
+---@field disabled? boolean
+---@field tree table
+---@field level integer
+---@field parent? AceGUITreeGroupLine
+---@field visible? boolean
+---@field uniquevalue string
+---@field hasChildren? boolean

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-Window.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIContainer-Window.lua
@@ -1,6 +1,23 @@
 ---@meta _
----@class AceGUIWindow
+---@class AceGUIWindow : AceGUIContainer
+---@field protected status? table
+---@field protected localstatus table
+---@field protected closebutton Button
+---@field protected titletext FontString
+---@field protected title Button
+---@field protected sizer_se Frame
+---@field protected line1 Texture
+---@field protected line2 Texture
+---@field protected sizer_s Frame
+---@field protected sizer_e Frame
 local AceGUIWindow = {}
+
+function AceGUIWindow:Hide() end
+
+function AceGUIWindow:Show() end
+
+function AceGUIWindow:ApplyStatus() end
+
 ---@param title string
 function AceGUIWindow:SetTitle(title) end
 

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Button.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Button.lua
@@ -1,6 +1,8 @@
 ---@meta _
 ---@class AceGUIButton : AceGUIWidget
+---@field protected text FontString
 local AceGUIButton = {}
+
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-1-1)
 ---@param text string
 function AceGUIButton:SetText(text) end

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-CheckBox.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-CheckBox.lua
@@ -1,6 +1,12 @@
 ---@meta _
 ---@class AceGUICheckBox : AceGUIWidget
+---@field protected checkbg Texture
+---@field protected check Texture
+---@field protected text FontString
+---@field protected highlight Texture
+---@field protected image Texture
 local AceGUICheckBox = {}
+
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-2-1)
 ---@param flag boolean|nil
 function AceGUICheckBox:SetValue(flag) end

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-ColorPicker.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-ColorPicker.lua
@@ -1,6 +1,9 @@
 ---@meta _
 ---@class AceGUIColorPicker : AceGUIWidget
+---@field protected colorSwatch Texture
+---@field protected text FontString
 local AceGUIColorPicker = {}
+
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-3-1)
 ---@param r number
 ---@param g number

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-DropDown.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-DropDown.lua
@@ -1,6 +1,13 @@
 ---@meta _
 ---@class AceGUIDropdown : AceGUIWidget
+---@field protected dropdown Frame
+---@field protected count number
+---@field protected button Button
+---@field protected button_cover Button
+---@field protected text FontString
+---@field protected label FontString
 local AceGUIDropdown = {}
+
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-4-1)
 ---@param key unknown
 function AceGUIDropdown:SetValue(key) end

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-EditBox.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-EditBox.lua
@@ -1,5 +1,9 @@
 ---@meta _
 ---@class AceGUIEditBox : AceGUIWidget
+---@field protected alignoffset number
+---@field protected editbox EditBox
+---@field protected label FontString
+---@field protected button Button
 local AceGUIEditBox = {}
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-5-1)
 ---@param text string

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Heading.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Heading.lua
@@ -1,6 +1,10 @@
 ---@meta _
 ---@class AceGUIHeading : AceGUIWidget
+---@field protected label FontString
+---@field protected left Texture
+---@field protected right Texture
 local AceGUIHeading = {}
+
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-6-1)
 ---@param text string
 function AceGUIHeading:SetText(text) end

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Icon.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Icon.lua
@@ -2,7 +2,6 @@
 ---@class AceGUIIcon : AceGUIWidget
 ---@field protected label FontString
 ---@field protected image Texture
----@field protected highlight Texture
 local AceGUIIcon = {}
 
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-7-1)

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Icon.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Icon.lua
@@ -1,6 +1,10 @@
 ---@meta _
 ---@class AceGUIIcon : AceGUIWidget
+---@field protected label FontString
+---@field protected image Texture
+---@field protected highlight Texture
 local AceGUIIcon = {}
+
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-7-1)
 ---@param image string|number
 ---@param ...? unknown

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-InteractiveLabel.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-InteractiveLabel.lua
@@ -1,6 +1,8 @@
 ---@meta _
 ---@class AceGUIInteractiveLabel : AceGUIWidget
+---@field protected highlight Texture
 local AceGUIInteractiveLabel = {}
+
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-8-1)
 ---@param text string
 function AceGUIInteractiveLabel:SetText(text) end

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Keybinding.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Keybinding.lua
@@ -1,6 +1,11 @@
 ---@meta _
 ---@class AceGUIKeybinding : AceGUIWidget
+---@field protected button Button
+---@field protected label FontString
+---@field protected msgframe Frame|BackdropTemplate
+---@field protected alignoffset number
 local AceGUIKeybinding = {}
+
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-9-1)
 ---@param key string
 function AceGUIKeybinding:SetKey(key) end

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Label.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Label.lua
@@ -1,6 +1,9 @@
 ---@meta _
 ---@class AceGUILabel : AceGUIWidget
+---@field protected label FontString
+---@field protected image Texture
 local AceGUILabel = {}
+
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-10-1)
 ---@param text string
 function AceGUILabel:SetText(text) end

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-MultiLineEditBox.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-MultiLineEditBox.lua
@@ -1,6 +1,15 @@
 ---@meta _
 ---@class AceGUIMultiLineEditBox : AceGUIWidget
+---@field protected button Button
+---@field protected editBox EditBox
+---@field protected label FontString
+---@field protected labelHeight number
+---@field protected numlines number
+---@field protected scrollBar Frame
+---@field protected scrollBG Frame|BackdropTemplate
+---@field protected scrollFrame ScrollFrame
 local AceGUIMultiLineEditBox = {}
+
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-11-1)
 ---@param text string
 function AceGUIMultiLineEditBox:SetText(text) end

--- a/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Slider.lua
+++ b/Annotations/Libraries/Ace3/AceGUI-3.0/widgets/AceGUIWidget-Slider.lua
@@ -1,6 +1,13 @@
 ---@meta _
 ---@class AceGUISlider : AceGUIWidget
+---@field protected label FontString
+---@field protected slider Slider|BackdropTemplate
+---@field protected lowtext FontString
+---@field protected hightext FontString
+---@field protected editbox EditBox|BackdropTemplate
+---@field protected alignoffset number
 local AceGUISlider = {}
+
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/ace-gui-3-0-widgets#title-2-12-1)
 ---@param value number
 function AceGUISlider:SetValue(value) end


### PR DESCRIPTION
* Add the `Table` layout as a valid `AceGUILayoutType`
* Add BlizOptionsGroup
* Add `@protected` fields and functions to all AceGUI widgets and containers, these will not show up in auto-completion suggestions unless you're working on a `@class` that inherits from a widget.