### PR TITLE
Update AceComm documentation

### DIFF
--- a/Annotations/Libraries/Ace3/AceComm-3.0.lua
+++ b/Annotations/Libraries/Ace3/AceComm-3.0.lua
@@ -4,10 +4,16 @@
 local AceComm = {}
 
 ---@param prefix string A printable character (\032-\255) classification of the message (typically AddonName or AddonNameEvent), max 16 characters
----@param method function? OPTIONAL: Callback to call on message reception: Function reference, or method name (string) to call on self. Defaults to "OnCommReceived"
+---@param method? function|string OPTIONAL: Callback to call on message reception: Function reference, or method name (string) to call on self. Defaults to "OnCommReceived"
 --- ---
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-comm-3-0#title-1)
 function AceComm:RegisterComm(prefix, method) end
+
+---@param eventname string
+function AceComm:UnregisterComm(eventname) end
+
+---@param ... table
+function AceComm:UnregisterAllComm(...) end
 
 ---@param prefix string A printable character (\032-\255) classification of the message (typically AddonName or AddonNameEvent)
 ---@param text string Data to send, nils (\000) not allowed. Any length.
@@ -19,3 +25,30 @@ function AceComm:RegisterComm(prefix, method) end
 --- ---
 ---[Documentation](https://www.wowace.com/projects/ace3/pages/api/ace-comm-3-0#title-1)
 function AceComm:SendCommMessage(prefix, text, distribution, target, prio, callbackFn, callbackArg) end
+
+---@param target table
+function AceComm:Embed(target) end
+
+---@param target table
+function AceComm:OnEmbedDisable(target) end
+
+---@protected
+---@param prefix string
+---@param message string
+---@param distribution string
+---@param sender string
+function AceComm:OnReceiveMultipartFirst(prefix, message, distribution, sender) end
+
+---@protected
+---@param prefix string
+---@param message string
+---@param distribution string
+---@param sender string
+function AceComm:OnReceiveMultipartNext(prefix, message, distribution, sender) end
+
+---@protected
+---@param prefix string
+---@param message string
+---@param distribution string
+---@param sender string
+function AceComm:OnReceiveMultipartLast(prefix, message, distribution, sender) end


### PR DESCRIPTION
I think the `OnReceiveMultipartFirst`, `OnReceiveMultipartNext`, `OnReceiveMultipartLast` are correct to be defined as `@protected`, but I'm not entirely sure