### PR TITLE
[1/3] add .lua to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 
 *.xml
 LuaScripts/Data
+/.lua


### PR DESCRIPTION

`bin/setup.sh` puts the hererocks install in `.lua`, so that should be gitignored
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Ketho/vscode-wow-api/pull/167).
* #169
* #168
* __->__ #167