### PR TITLE
[2/3] monkey-patch PetConsts correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 
 *.xml
 LuaScripts/Data
+/.lua

--- a/LuaScripts/WowDocLoader/Fixes.lua
+++ b/LuaScripts/WowDocLoader/Fixes.lua
@@ -1,13 +1,24 @@
-if not MAX_STABLE_SLOTS then -- 10.2.7
-    MAX_STABLE_SLOTS = -1
-    EXTRA_PET_STABLE_SLOT = -1
-    NUM_PET_SLOTS_THAT_NEED_LEARNED_SPELL = -1
+local Fixes = {}
+
+function Fixes:Run()
+    if not MAX_STABLE_SLOTS then -- 10.2.7
+        MAX_STABLE_SLOTS = -1
+        EXTRA_PET_STABLE_SLOT = -1
+        NUM_PET_SLOTS_THAT_NEED_LEARNED_SPELL = -1
+    end
+
+    if Constants then -- 11.0.2
+        Constants.PetConsts = Constants.PetConsts or {}
+        for _, name in ipairs({
+            "MAX_STABLE_SLOTS",
+            "EXTRA_PET_STABLE_SLOT",
+            "NUM_PET_SLOTS_THAT_NEED_LEARNED_SPELL",
+        }) do
+            if Constants.PetConsts[name] == nil then
+                Constants.PetConsts[name] = -1
+            end
+        end
+    end
 end
 
-if Constants and not Constants.PetConsts then -- 11.0.2
-    Constants.PetConsts = {
-        MAX_STABLE_SLOTS = -1,
-        EXTRA_PET_STABLE_SLOT = -1,
-        NUM_PET_SLOTS_THAT_NEED_LEARNED_SPELL = -1,
-    }
-end
+return Fixes

--- a/LuaScripts/WowDocLoader/Loader.lua
+++ b/LuaScripts/WowDocLoader/Loader.lua
@@ -3,7 +3,7 @@ local Path = require "path"
 local Util = require("LuaScripts.Util.Util")
 local Mitsuha = require("LuaScripts.Mitsuha.MitsuhaMain")
 local patches = require("LuaScripts.WowDocLoader.Patches")
-require("LuaScripts.WowDocLoader.Fixes")
+local Fixes = require("LuaScripts.WowDocLoader.Fixes")
 local m = {}
 
 local API_DOC = "Blizzard_APIDocumentation"
@@ -60,6 +60,7 @@ end
 
 function m:main()
 	Util:MakeDir(GEN_PATH)
+	Fixes:Run()
 	require(Path.join(WowDocLoader_Path, "Compat"))
 	LoadAddon(Path.join(WowDocLoader_Path, API_DOC), API_DOC)
 


### PR DESCRIPTION

`LuaScripts/main.lua` is failing to run because the fixes for the missing `PetConsts` values doesn't work with the current set of downloaded files.

This diff fixes the monkey-patching by:
- Running it during the invocation of `Loader:main()` instead of during the loading of `Loader.lua`. This reduces the risk of the fixes being overwritten by something else.
- Making it add missing values per-key instead of doing all-or-nothing on `PetConsts`. This was a problem because the most recent version of `LuaEnum.lua` includes `PetConsts`, but is missing some keys that are referenced in the docs.

After this fix, I was able to successfully run `LuaScripts/main.lua` and the results of that run are the next diff in this stack.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Ketho/vscode-wow-api/pull/168).
* #169
* __->__ #168
* #167