### PR TITLE
Fix SharedMenuDescriptionProxy:EnumerateElementDescriptions()

### DIFF
--- a/Annotations/Interface/Blizzard_Menu/Proxies/SharedMenuDescriptionProxy.lua
+++ b/Annotations/Interface/Blizzard_Menu/Proxies/SharedMenuDescriptionProxy.lua
@@ -6,7 +6,7 @@ local SharedMenuDescriptionProxy = {}
 ---@return boolean
 function SharedMenuDescriptionProxy:HasElements() end
 
----@return fun(): ElementMenuDescriptionProxy
+---@return fun(): number, ElementMenuDescriptionProxy
 function SharedMenuDescriptionProxy:EnumerateElementDescriptions() end
 
 ---@param elementDescription ElementMenuDescriptionProxy


### PR DESCRIPTION
now correctly identifies `i` and `elementDescription` in `for i, elementDescription in rootDescription:EnumerateElementDescriptions() do`