### PR TITLE
callback is optional in SharedMenuDescriptionProxy:CreateButton

### DIFF
--- a/Annotations/Interface/Blizzard_Menu/Proxies/SharedMenuDescriptionProxy.lua
+++ b/Annotations/Interface/Blizzard_Menu/Proxies/SharedMenuDescriptionProxy.lua
@@ -30,7 +30,7 @@ function SharedMenuDescriptionProxy:CreateSpacer(extend) end
 
 ---@see MenuUtil.CreateButton
 ---@param text string
----@param callback MenuResponder
+---@param callback MenuResponder?
 ---@param data any? # stored as element's data
 ---@return ElementMenuDescriptionProxy
 function SharedMenuDescriptionProxy:CreateButton(text, callback, data) end


### PR DESCRIPTION
text-only menu items are added by adding a button without a callback